### PR TITLE
Sorting rules and non real-time departure times

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -36,6 +36,13 @@ module.exports = NodeHelper.create({
         });
       }
     }
+    else if (notification === "DECREMENT_SL") {
+
+      console.log("Lets decrement the SL data");
+
+      this.sendSocketNotification("SL_DECREMENT_TIMERS");
+
+    }
   },
 
   getParams: function(siteId) {


### PR DESCRIPTION
I wanted to monitor several stops at the same time. To make sure I didn't go over the API request limit, I had to set the timer for more than 10 minutes. To make sure I had trains/buses in my list that hadn't departed yet, I set the time window to 30 minutes. This lead to 2 issues for me: First, the information displayed could be up to 10 minutes old and since the departure times are based on the time of the request, old departures remain in the list. Second, with a larger time window, the format of the display time varies between entries and was not being properly sorted by departure time.

The decrementTimers function counts down the time to departure by one minute every time it is called. If a timer would be counted down to '0 min', it is instead set to 'Nu'. A departure which was 'Nu' is set to 'Nyss', and a departure which was 'Nyss' is removed from the list. The function can be triggered by sending a DECREMENT_SL notification. If no such notifications are sent, the module behaves as before and updates only with real-time information when receiving a UPDATE_SL notification. I'm using MMM-ModuleScheduler to send both types of notifications with the following configuration in the config.js file:
```
{
  module: 'MMM-ModuleScheduler',
  config: {
    notification_schedule: [
      { notification: 'UPDATE_SL', schedule: '0,15,30,45 6-23 * * *', },
      { notification: 'DECREMENT_SL', schedule: '1-14,16-29,31-44,46-59 6-23 * * *', },
    ],
  },
},
```


For the second issue, I used regular expressions to create sorting rules for the different formats of DisplayTime. The rules are:

1. 'Nu' should come before any other string
2. Single digit 'minutes remaining' should come before double digit 'minutes remaining'
3. All 'minutes remaining' strings should come before all 'specific times'
4. Single digit 'specific times' should come before double digit 'specific times'

Previously, an entry with DisplayTime '10 min' could be displayed before an entry with DisplayTime '2 min', since '1' is lexicographically smaller than '2'. Similarly for DisplayTime '8 min' compared to Displaytime '7:52'.